### PR TITLE
Options page for selecting page to load on click.

### DIFF
--- a/Crunchyroll Unblocker/background.js
+++ b/Crunchyroll Unblocker/background.js
@@ -14,11 +14,20 @@ function setCookie (tld) {
 	xhr.send(null);
 }
 
+function openStartPage()
+{
+	chrome.storage.sync.get({
+		startPage: "home/queue"
+	}, function(items) {
+		// Page that opens when done.
+		// This fork sets this to queue page.
+		chrome.tabs.create({url: "http://www.crunchyroll.com/"+items.startPage});
+	});
+}
+
 chrome.browserAction.onClicked.addListener (function () {
 	setCookie(".com");
-	// Page that opens when done.
-	// This fork sets this to queue page.
-	chrome.tabs.create({url: "http://www.crunchyroll.com/home/queue"});
+	openStartPage();
 });
 
 chrome.runtime.onMessage.addListener(function (message) { 

--- a/Crunchyroll Unblocker/background.js
+++ b/Crunchyroll Unblocker/background.js
@@ -3,20 +3,22 @@ function setCookie (tld) {
 	xhr.timeout = 5000;
 	xhr.ontimeout = function () {
 		chrome.notifications.create("", {type: "basic", title: "Request Timed Out", message: "Crunchyroll Unblocker has encounted an error", iconUrl: "crunblock128.png"}, function (notificationId) {});
-	}
+	};
 	xhr.onreadystatechange = function () {
 		if (xhr.readyState == 4) {
 			chrome.cookies.remove({url: "http://crunchyroll" + tld + "/", name: "sess_id"});
 			chrome.cookies.set({url: "http://.crunchyroll" + tld + "/", name: "sess_id", value: xhr.responseText});
 		}
-	}
+	};
 	xhr.open("GET", "http://www.crunblocker.com/sess_id.php", true);
 	xhr.send(null);
 }
 
 chrome.browserAction.onClicked.addListener (function () {
 	setCookie(".com");
-	chrome.tabs.create({url: "http://crunchyroll.com/videos/anime/"});
+	// Page that opens when done.
+	// This fork sets this to queue page.
+	chrome.tabs.create({url: "http://www.crunchyroll.com/home/queue"});
 });
 
 chrome.runtime.onMessage.addListener(function (message) { 

--- a/Crunchyroll Unblocker/background.js
+++ b/Crunchyroll Unblocker/background.js
@@ -1,3 +1,7 @@
+// Default page for first time
+var defaultPage = "videos/anime";
+var mainUrl = "http://www.crunchyroll.com/";
+
 function setCookie (tld) {
 	var xhr = new XMLHttpRequest();
 	xhr.timeout = 5000;
@@ -17,11 +21,11 @@ function setCookie (tld) {
 function openStartPage()
 {
 	chrome.storage.sync.get({
-		startPage: "home/queue"
+		startPage: defaultPage
 	}, function(items) {
 		// Page that opens when done.
 		// This fork sets this to queue page.
-		chrome.tabs.create({url: "http://www.crunchyroll.com/"+items.startPage});
+		chrome.tabs.create({url: mainUrl + items.startPage});
 	});
 }
 

--- a/Crunchyroll Unblocker/manifest.json
+++ b/Crunchyroll Unblocker/manifest.json
@@ -32,5 +32,7 @@
 	
 	"background": {
 		"scripts": ["background.js"]
-	}
+	},
+
+	"options_page": "options.html"
 }

--- a/Crunchyroll Unblocker/options.html
+++ b/Crunchyroll Unblocker/options.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Options: Crunchyroll Unblocker</title>
+</head>
+<body>
+    <h1>Options</h1>
+    <form>
+        <label for="startPage">Start Page: </label>http://www.crunchyroll.com/<input id="startPage" type="url"/>
+    </form>
+    <br>
+    <div id="status"></div>
+    <button id="save">Save</button>
+
+    <script src="options.js"></script>
+</body>
+</html>

--- a/Crunchyroll Unblocker/options.js
+++ b/Crunchyroll Unblocker/options.js
@@ -1,0 +1,30 @@
+/**
+ * Created by Santeri Hetekivi on 2/18/16.
+ */
+
+//Saving options to browser's storage
+function save_options() {
+    var startPage = document.getElementById("startPage").value;
+    chrome.storage.sync.set({
+        startPage: startPage
+    }, function() {
+        // Update status to let user know options were saved.
+        var status = document.getElementById('status');
+        status.textContent = 'Options saved.';
+        setTimeout(function() {
+            status.textContent = '';
+        }, 750);
+    });
+}
+
+// Restoring options from browser's storage
+function restore_options() {
+    chrome.storage.sync.get({
+        startPage: "home/queue"
+    }, function(items) {
+        document.getElementById('startPage').value = items.startPage;
+    });
+}
+
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click', save_options);

--- a/Crunchyroll Unblocker/options.js
+++ b/Crunchyroll Unblocker/options.js
@@ -2,7 +2,10 @@
  * Created by Santeri Hetekivi on 2/18/16.
  */
 
-//Saving options to browser's storage
+// Default page for first time
+var defaultPage = "videos/anime";
+
+// Saving options to browser's storage
 function save_options() {
     var startPage = document.getElementById("startPage").value;
     chrome.storage.sync.set({
@@ -20,7 +23,7 @@ function save_options() {
 // Restoring options from browser's storage
 function restore_options() {
     chrome.storage.sync.get({
-        startPage: "home/queue"
+        startPage: defaultPage
     }, function(items) {
         document.getElementById('startPage').value = items.startPage;
     });

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Crunchyroll Unblocker extension for Chrome.
 Fork by: Santeri Hetekivi
 =====================
 
-Page that loads on clock set to queue page.
+Added Options page for setting the page that loads on click.

--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@ Crunchyroll-Unblocker
 =====================
 
 Crunchyroll Unblocker extension for Chrome.
+
+
+
+Fork by: Santeri Hetekivi
+=====================
+
+Page that loads on clock set to queue page.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,3 @@ Crunchyroll-Unblocker
 =====================
 
 Crunchyroll Unblocker extension for Chrome.
-
-
-
-Fork by: Santeri Hetekivi
-=====================
-
-Added Options page for setting the page that loads on click.


### PR DESCRIPTION
Hi

I'm long time user of this extension.
But I had only one problem with it:

I have Crunchyroll account and use the queue page for my home page so I would always need to click queue button after I have clicked the extension.

So I made a simple option page to change the page that load when you click the extension.
It is not pretty but works. ;)

Only change to your logic was that my code loads the page to use when opening the tab from browsers memory. (and couple of terminators because my IDE was warning me of not using them :) )
Default page is still videos/anime that your version uses, but now you can go to extension's options page and change it.

Sincerely.
Santeri Hetekivi